### PR TITLE
Updated manifest.yml to cf v2 conventions

### DIFF
--- a/spring/manifest.yml
+++ b/spring/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: rabbitmq-spring
   memory: 512M
   instances: 1
-  url: rabbitmq-spring.${target-base}
+  host: rabbitmq-spring-${target-base}
   path: target/rabbitmq-spring-1.0-SNAPSHOT.war
   services:
     rabbit-sample:


### PR DESCRIPTION
v2 doesn't support url attribute, updated to host and changed the '.' to '-' to get first deployment to work.
